### PR TITLE
Add Cookie Consent v3 integration

### DIFF
--- a/attila-2.0/static/js/cookieconsent-config.js
+++ b/attila-2.0/static/js/cookieconsent-config.js
@@ -1,0 +1,71 @@
+import 'https://cdn.jsdelivr.net/gh/orestbida/cookieconsent@3.1.0/dist/cookieconsent.umd.js';
+
+// Enable dark mode
+document.documentElement.classList.add('cc--darkmode');
+
+CookieConsent.run({
+    guiOptions: {
+        consentModal: {
+            layout: "box",
+            position: "bottom left",
+            equalWeightButtons: true,
+            flipButtons: false
+        },
+        preferencesModal: {
+            layout: "box",
+            position: "right",
+            equalWeightButtons: true,
+            flipButtons: false
+        }
+    },
+    categories: {
+        necessary: {
+            readOnly: true
+        },
+        analytics: {}
+    },
+    language: {
+        default: "it",
+        autoDetect: "browser",
+        translations: {
+            it: {
+                consentModal: {
+                    title: "Ciao viaggiatore, è tempo di biscotti!",
+                    description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip.",
+                    acceptAllBtn: "Accetta tutto",
+                    acceptNecessaryBtn: "Rifiuta tutto",
+                    showPreferencesBtn: "Gestisci preferenze",
+                    footer: "<a href=\"#link\">Informativa sulla privacy</a>\n<a href=\"#link\">Termini e condizioni</a>"
+                },
+                preferencesModal: {
+                    title: "Centro preferenze per il consenso",
+                    acceptAllBtn: "Accetta tutto",
+                    acceptNecessaryBtn: "Rifiuta tutto",
+                    savePreferencesBtn: "Salva le preferenze",
+                    closeIconLabel: "Chiudi la finestra",
+                    serviceCounterLabel: "Servizi",
+                    sections: [
+                        {
+                            title: "Utilizzo dei Cookie",
+                            description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
+                        },
+                        {
+                            title: "Cookie Strettamente Necessari <span class=\"pm__badge\">Sempre Attivati</span>",
+                            description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
+                            linkedCategory: "necessary"
+                        },
+                        {
+                            title: "Cookie Analitici",
+                            description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
+                            linkedCategory: "analytics"
+                        },
+                        {
+                            title: "Ulteriori informazioni",
+                            description: "For any query in relation to my policy on cookies and your choices, please <a class=\"cc__link\" href=\"#yourdomain.com\">contact me</a>."
+                        }
+                    ]
+                }
+            }
+        }
+    }
+});

--- a/attila-2.0/templates/base.html
+++ b/attila-2.0/templates/base.html
@@ -73,6 +73,7 @@
   {% endfor %}
 
   <link href="{{ SITEURL }}/{{ THEME_STATIC_DIR }}/css/style.css" type="text/css" rel="stylesheet" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/orestbida/cookieconsent@3.1.0/dist/cookieconsent.css">
 
   {% if CSS_OVERRIDE %}
   <!-- CSS specified by the user -->
@@ -235,6 +236,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/highlight.min.js"></script>
   <script type="text/javascript" src="{{ SITEURL }}/{{ THEME_STATIC_DIR }}/js/jquery.fitvids.js"></script>
   <script type="text/javascript" src="{{ SITEURL }}/{{ THEME_STATIC_DIR }}/js/script.js"></script>
+  <script type="module" src="{{ SITEURL }}/{{ THEME_STATIC_DIR }}/js/cookieconsent-config.js"></script>
 
   {% if JS_OVERRIDE %}
   <!-- Script specified by the user -->


### PR DESCRIPTION
## Summary
- add cookieconsent configuration script under theme static files
- load cookie consent stylesheet and module in base template

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*