### PR TITLE
Setup GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,30 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main, master]
+
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pelican ghp-import
+      - name: Build static site
+        run: |
+          pelican content -o output -s pelicanconf.py
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./output
+          publish_branch: gh-pages
+          keep_files: false
+          force_orphan: true
+

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ bin/*
 *.dist-info
 dist/
 applicazione.zip
+output/


### PR DESCRIPTION
## Summary
- ignore the Pelican build directory `output/`
- add a GitHub Actions workflow that builds the site with Pelican and deploys it to GitHub Pages

## Testing
- `make html` *(fails: pelican not found)*
- `pip install pelican` *(fails: cannot connect to proxy)*