### PR TITLE
Configure SITEURL for GitHub Pages

### DIFF
--- a/publishconf.py
+++ b/publishconf.py
@@ -8,7 +8,7 @@ sys.path.append(os.curdir)
 from pelicanconf import *
 
 # If your site is available via HTTPS, make sure SITEURL begins with https://
-SITEURL = "https://assolutamenteinutile.it"
+SITEURL = "https://menteora.github.io/blog-pelican"
 RELATIVE_URLS = False
 
 FEED_ALL_ATOM = "feeds/all.atom.xml"


### PR DESCRIPTION
## Summary
- update `publishconf.py` so the site builds with the GitHub Pages base URL

## Testing
- `pytest -q` *(fails: No module named pytest)*