### PR TITLE
Move GTM id to config

### DIFF
--- a/attila-2.0/templates/base.html
+++ b/attila-2.0/templates/base.html
@@ -145,15 +145,17 @@
     {% endif %}
   {% endif %}
 
+  {% if GOOGLE_TAG_ID %}
   <!-- Google Tag Manager -->
   <script type="text/plain" data-category="analytics">
     (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-P79M6DH5');
+    })(window,document,'script','dataLayer','{{ GOOGLE_TAG_ID }}');
   </script>
   <!-- End Google Tag Manager -->
+  {% endif %}
 
   {% endblock head %}
 
@@ -204,10 +206,12 @@
 
 
 <body class="{{body_class}}">
+  {% if GOOGLE_TAG_ID %}
   <!-- Google Tag Manager (noscript) -->
-  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P79M6DH5"
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ GOOGLE_TAG_ID }}"
   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <!-- End Google Tag Manager (noscript) -->
+  {% endif %}
 
   {% include 'partials/navigation.html' %}
 

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -35,3 +35,6 @@ DEFAULT_PAGINATION = 10
 # RELATIVE_URLS = True
 
 THEME = "attila-2.0"
+
+# Google Tag Manager ID
+GOOGLE_TAG_ID = "GTM-P79M6DH5"


### PR DESCRIPTION
## Summary
- add `GOOGLE_TAG_ID` setting to the Pelican config
- read that value in the theme template

## Testing
- `make html` *(fails: pelican not found)*