### PR TITLE
Remove Google Tag Manager integration

### DIFF
--- a/attila-2.0/templates/base.html
+++ b/attila-2.0/templates/base.html
@@ -145,17 +145,6 @@
     {% endif %}
   {% endif %}
 
-  {% if GOOGLE_TAG_ID %}
-  <!-- Google Tag Manager -->
-  <script type="text/plain" data-category="analytics">
-    (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','{{ GOOGLE_TAG_ID }}');
-  </script>
-  <!-- End Google Tag Manager -->
-  {% endif %}
 
   {% endblock head %}
 
@@ -206,12 +195,6 @@
 
 
 <body class="{{body_class}}">
-  {% if GOOGLE_TAG_ID %}
-  <!-- Google Tag Manager (noscript) -->
-  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ GOOGLE_TAG_ID }}"
-  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-  <!-- End Google Tag Manager (noscript) -->
-  {% endif %}
 
   {% include 'partials/navigation.html' %}
 

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -36,5 +36,3 @@ DEFAULT_PAGINATION = 10
 
 THEME = "attila-2.0"
 
-# Google Tag Manager ID
-GOOGLE_TAG_ID = "GTM-P79M6DH5"


### PR DESCRIPTION
## Summary
- remove Google Tag Manager from the theme
- drop `GOOGLE_TAG_ID` from the Pelican configuration

## Testing
- `pytest` *(fails: command not found)*