### PR TITLE
Add hero image cover configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ dist/
 applicazione.zip
 output/
 commit.py
+.venv/

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -36,3 +36,6 @@ DEFAULT_PAGINATION = 10
 
 THEME = "attila-2.0"
 
+# Default hero image for the home page
+HOME_COVER = "theme/images/hero-image.png"
+


### PR DESCRIPTION
## Summary
- ignore virtualenv directory
- show hero image on homepage using theme cover

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'six')*